### PR TITLE
Rewrite `NamedPipeClientReader::read_full` to avoid memory unsafety

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -301,11 +301,12 @@ impl NamedPipeClientReader {
             }
 
             let err = unsafe { GetLastError().unwrap_err() };
-            if err.code() == ERROR_MORE_DATA.into() {
-                // The read succeeded, but this message has more data
-            } else {
+            if err.code() != ERROR_MORE_DATA.into() {
+                // An error occurred during reading
                 return Err(err);
             }
+
+            // Read succeeded, but this message has more data
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -269,38 +269,43 @@ impl NamedPipeClientReader {
 
     /// Read full message/bytes into a vec
     pub fn read_full(&self) -> Result<Vec<u8>, Error> {
-        let buffer_size = self.options.read_buffer_size;
+        let buffer_size = std::cmp::max(self.options.read_buffer_size as usize, 1);
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(buffer_size as usize);
+        let mut buffer = Vec::new();
+        let mut total_read_bytes = 0;
 
-        let mut buffer_to_read = buffer_size;
-        let mut buffer_ptr = 0;
-        let mut read_bytes = 0;
+        loop {
+            let old_buffer_size = buffer.len();
+            let new_buffer_size = old_buffer_size + buffer_size;
+            buffer.resize(new_buffer_size, 0);
 
-        while unsafe {
-            ReadFileSys(
-                self.handle.0 .0,
-                buffer.as_mut_ptr().add(buffer_ptr) as *mut _,
-                buffer_to_read,
-                &mut read_bytes,
-                std::ptr::null_mut(),
-            ) == 0
-        } {
-            let err = unsafe { GetLastError().unwrap_err() };
-            if err.code() != ERROR_MORE_DATA.into() {
-                return Err(err);
+            let buffer_end = &mut buffer[old_buffer_size..];
+            let mut read_bytes = 0;
+            let result = unsafe {
+                ReadFileSys(
+                    self.handle.0 .0,
+                    buffer_end.as_mut_ptr(),
+                    buffer_end.len() as u32,
+                    &mut read_bytes,
+                    std::ptr::null_mut(),
+                )
+            };
+
+            total_read_bytes += read_bytes as usize;
+
+            if result != 0 {
+                // Read was successful
+                buffer.resize(total_read_bytes, 0);
+                return Ok(buffer);
             }
 
-            buffer_to_read = self.available_bytes()?.0;
-            buffer.reserve_exact(buffer_to_read as usize);
-            buffer_ptr += read_bytes as usize;
+            let err = unsafe { GetLastError().unwrap_err() };
+            if err.code() == ERROR_MORE_DATA.into() {
+                // The read succeeded, but this message has more data
+            } else {
+                return Err(err);
+            }
         }
-
-        unsafe {
-            buffer.set_len(buffer_ptr + read_bytes as usize);
-        }
-
-        Ok(buffer)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -191,6 +191,7 @@ impl NamedPipeClientOptions {
     }
 
     pub fn read_buffer_size(mut self, size: u32) -> Self {
+        assert!(size > 0, "size must be > 0");
         self.read_buffer_size = size;
         self
     }
@@ -269,7 +270,7 @@ impl NamedPipeClientReader {
 
     /// Read full message/bytes into a vec
     pub fn read_full(&self) -> Result<Vec<u8>, Error> {
-        let buffer_size = std::cmp::max(self.options.read_buffer_size as usize, 1);
+        let buffer_size = self.options.read_buffer_size as usize;
 
         let mut buffer = Vec::new();
         let mut total_read_bytes = 0;


### PR DESCRIPTION
This PR includes a reworked implementation of the `NamedPipeClientReader::read_full` method to prefer safe methods on `Vec` where possible. The new implementation is theoretically less efficient, since there will likely be more bounds checks, and additionally it doesn't try to optimize reallocation like the previous implementation did using `PeekNamedPipe`. However, it fixes the crash I reported in #1 (see that issue for more context).

I _think_ it would be possible to build on this PR to restore some of these previous optimizations, including by switching back to the unsafe methods from `Vec`. I'd personally be reluctant to doing so as it seems pretty easy to screw up the pointer math here, and I'd guess the performance win would be nearly unmeasurable for most real-world use-cases.